### PR TITLE
Added option to install PubSub emulator

### DIFF
--- a/src/google-cloud-cli/devcontainer-feature.json
+++ b/src/google-cloud-cli/devcontainer-feature.json
@@ -14,6 +14,11 @@
             "type": "boolean",
             "default": false,
             "description": "Install 'gke-gcloud-auth-plugin' plugin?"
+        },
+        "installPubSubEmulator": {
+            "type": "boolean",
+            "default": false,
+            "description": "Install the 'google-cloud-cli-pubsub-emulator'?"
         }
     },
     "installsAfter": [

--- a/src/google-cloud-cli/install.sh
+++ b/src/google-cloud-cli/install.sh
@@ -7,6 +7,7 @@ rm -rf /var/lib/apt/lists/*
 
 GCLOUD_VERSION=${VERSION:-"latest"}
 INSTALL_GKEGCLOUDAUTH_PLUGIN="${INSTALLGKEGCLOUDAUTHPLUGIN:-"false"}"
+INSTALL_PUBSUB_EMULATOR="${INSTALLPUBSUBEMULATOR:-"false"}"
 
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
@@ -93,6 +94,12 @@ install_using_apt() {
     if [ "${INSTALL_GKEGCLOUDAUTH_PLUGIN}" = "true" ]; then
         echo "(*) Installing 'gke-gcloud-auth-plugin' plugin..."
         check_packages google-cloud-sdk-gke-gcloud-auth-plugin
+    fi
+
+    # Install pubsub emulator if needed
+    if [ "${INSTALL_PUBSUB_EMULATOR}" = "true" ]; then
+        echo "(*) Installing 'pubsub-emulator' plugin..."
+        check_packages google-cloud-cli-pubsub-emulator
     fi
 }
 

--- a/src/google-cloud-cli/install.sh
+++ b/src/google-cloud-cli/install.sh
@@ -6,7 +6,7 @@ set -e
 rm -rf /var/lib/apt/lists/*
 
 GCLOUD_VERSION=${VERSION:-"latest"}
-INSTALL_GKEGCLOUDAUTH_PLUGIN="${INSTALL_GKEGCLOUDAUTH_PLUGIN:-"false"}"
+INSTALL_GKEGCLOUDAUTH_PLUGIN="${INSTALLGKEGCLOUDAUTHPLUGIN:-"false"}"
 
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'

--- a/test/google-cloud-cli/install_gke_auth_plugin.sh
+++ b/test/google-cloud-cli/install_gke_auth_plugin.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "gke-gcloud-auth-plugin is installed" grep "gke-gcloud-auth-plugin" <(gcloud --version)
+
+# Report result
+reportResults

--- a/test/google-cloud-cli/install_pubsub_emulator.sh
+++ b/test/google-cloud-cli/install_pubsub_emulator.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "pubsub-emulator is installed" grep "pubsub-emulator" <(gcloud --version)
+
+# Report result
+reportResults

--- a/test/google-cloud-cli/install_specific_version.sh
+++ b/test/google-cloud-cli/install_specific_version.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "gcloud version 430.0.0 installed" grep "430.0.0" <(gcloud --version)
+
+# Report result
+reportResults

--- a/test/google-cloud-cli/scenarios.json
+++ b/test/google-cloud-cli/scenarios.json
@@ -1,0 +1,26 @@
+{
+	"install_specific_version": {
+		"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+		"features": {
+			"google-cloud-cli": {
+				"version": "430.0.0"
+			}
+		}
+	},
+	"install_gke_auth_plugin": {
+		"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+		"features": {
+			"google-cloud-cli": {
+				"installGkeGcloudAuthPlugin": true
+			}
+		}
+	},
+	"install_pubsub_emulator": {
+		"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+		"features": {
+			"google-cloud-cli": {
+				"installPubsubEmulator": true
+			}
+		}
+	}
+}

--- a/test/google-cloud-cli/test.sh
+++ b/test/google-cloud-cli/test.sh
@@ -13,6 +13,8 @@ source dev-container-features-test-lib
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib.
 check "gcloud version" gcloud --version
+check "gke-gcloud-auth-plugin is not installed" [ "$(grep "gke-gcloud-auth-plugin" <(gcloud --version))" = "" ]
+check "pubsub-emulator is not installed" [ "$(grep "pubsub-emulator" <(gcloud --version))" = "" ]
 
 # Report result
 # If any of the checks above exited with a non-zero exit code, the test will fail.


### PR DESCRIPTION
This pull requests adds an `installPubSubEmulator` option to the `google-cloud-cli` feature.

```json
        "installPubSubEmulator": {
            "type": "boolean",
            "default": false,
            "description": "Install the 'google-cloud-cli-pubsub-emulator'?"
        }
```

This pull request also fixes a bug that prevented the GKE Gcloud Auth Plugin from being installed when the `installGkeGcloudAuthPlugin` was set to true.

Comprehensive tests for the `google-cloud-cli` options were also added.