### PR TITLE
Add api call to get latest flyctl version

### DIFF
--- a/src/flyctl/install.sh
+++ b/src/flyctl/install.sh
@@ -50,7 +50,9 @@ find_version_from_git_tags() {
         local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}$"
         local version_list="$(git ls-remote --tags ${repository} | grep -oP "${regex}" | tr -d ' ' | tr "${separator}" "." | sort -rV)"
         if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
-            declare -g ${variable_name}="$(echo "${version_list}" | head -n 1)"
+            LATEST_VERSION="$(curl -s https://api.github.com/repos/superfly/flyctl/releases/latest | jq -r '.tag_name')"
+            declare -g ${variable_name}="${LATEST_VERSION#"v"}"
+            echo "${LATEST_VERSION}"
         else
             set +e
             declare -g ${variable_name}="$(echo "${version_list}" | grep -E -m 1 "^${requested_version//./\\.}([\\.\\s]|$)")"


### PR DESCRIPTION
This fix the problem we currently have when trying to install fly in devcontainer. Because of name tag changes (see #25) we get tags that don't have a release download option, failing the installation when we want the latest version, which is the actual default behavior if you don't pass any specific version as argument.

This PR changes method to get latest release via an api call to the latest version via github api.