### PR TITLE
google-cloud-cli add optional packages

### DIFF
--- a/src/google-cloud-cli/README.md
+++ b/src/google-cloud-cli/README.md
@@ -16,7 +16,30 @@ Install google-cloud-cli
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
 | version | Select or enter a gcloud CLI version | string | latest |
-| installGkeGcloudAuthPlugin | Install 'gke-gcloud-auth-plugin' plugin? | boolean | false |
+| installanthosauth | Also install 'google-cloud-cli-anthos-auth' | boolean | false |
+| installappenginego | Also install 'google-cloud-cli-app-engine-go' | boolean | false |
+| installappenginegrpc | Also install 'google-cloud-cli-app-engine-grpc' | boolean | false |
+| installappenginejava | Also install 'google-cloud-cli-app-engine-java' | boolean | false |
+| installappenginepython | Also install 'google-cloud-cli-app-engine-python' | boolean | false |
+| installappenginepythonextras | Also install 'google-cloud-cli-app-engine-python-extras' | boolean | false |
+| installbigtableemulator | Also install 'google-cloud-cli-bigtable-emulator' | boolean | false |
+| installcbt | Also install 'google-cloud-cli-cbt' | boolean | false |
+| installcloudbuildlocal | Also install 'google-cloud-cli-cloud-build-local' | boolean | false |
+| installcloudrunproxy | Also install 'google-cloud-cli-cloud-run-proxy' | boolean | false |
+| installconfigconnector | Also install 'google-cloud-cli-config-connector' | boolean | false |
+| installdatastoreemulator | Also install 'google-cloud-cli-datastore-emulator' | boolean | false |
+| installfirestoreemulator | Also install 'google-cloud-cli-firestore-emulator' | boolean | false |
+| installgkegcloudauthplugin | Also install 'google-cloud-cli-gke-gcloud-auth-plugin' | boolean | false |
+| installkpt | Also install 'google-cloud-cli-kpt' | boolean | false |
+| installkubectloidc | Also install 'google-cloud-cli-kubectl-oidc' | boolean | false |
+| installlocalextract | Also install 'google-cloud-cli-local-extract' | boolean | false |
+| installminikube | Also install 'google-cloud-cli-minikube' | boolean | false |
+| installnomos | Also install 'google-cloud-cli-nomos' | boolean | false |
+| installpubsubemulator | Also install 'google-cloud-cli-pubsub-emulator' | boolean | false |
+| installskaffold | Also install 'google-cloud-cli-skaffold' | boolean | false |
+| installspanneremulator | Also install 'google-cloud-cli-spanner-emulator' | boolean | false |
+| installterraformvalidator | Also install 'google-cloud-cli-terraform-validator' | boolean | false |
+| installtests | Also install 'google-cloud-cli-tests' | boolean | false |
 
 
 

--- a/src/google-cloud-cli/devcontainer-feature.json
+++ b/src/google-cloud-cli/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Google Cloud CLI",
     "id": "google-cloud-cli",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Install google-cloud-cli",
     "documentationURL": "https://github.com/dhoeric/features/tree/main/src/google-cloud-cli",
     "options": {
@@ -10,10 +10,125 @@
             "default": "latest",
             "description": "Select or enter a gcloud CLI version"
         },
-        "installGkeGcloudAuthPlugin": {
+        "installanthosauth": {
             "type": "boolean",
             "default": false,
-            "description": "Install 'gke-gcloud-auth-plugin' plugin?"
+            "description": "Also install 'google-cloud-cli-anthos-auth'"
+        },
+        "installappenginego": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-app-engine-go'"
+        },
+        "installappenginegrpc": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-app-engine-grpc'"
+        },
+        "installappenginejava": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-app-engine-java'"
+        },
+        "installappenginepython": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-app-engine-python'"
+        },
+        "installappenginepythonextras": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-app-engine-python-extras'"
+        },
+        "installbigtableemulator": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-bigtable-emulator'"
+        },
+        "installcbt": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-cbt'"
+        },
+        "installcloudbuildlocal": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-cloud-build-local'"
+        },
+        "installcloudrunproxy": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-cloud-run-proxy'"
+        },
+        "installconfigconnector": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-config-connector'"
+        },
+        "installdatastoreemulator": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-datastore-emulator'"
+        },
+        "installfirestoreemulator": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-firestore-emulator'"
+        },
+        "installgkegcloudauthplugin": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-gke-gcloud-auth-plugin'"
+        },
+        "installkpt": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-kpt'"
+        },
+        "installkubectloidc": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-kubectl-oidc'"
+        },
+        "installlocalextract": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-local-extract'"
+        },
+        "installminikube": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-minikube'"
+        },
+        "installnomos": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-nomos'"
+        },
+        "installpubsubemulator": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-pubsub-emulator'"
+        },
+        "installskaffold": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-skaffold'"
+        },
+        "installspanneremulator": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-spanner-emulator'"
+        },
+        "installterraformvalidator": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-terraform-validator'"
+        },
+        "installtests": {
+            "type": "boolean",
+            "default": false,
+            "description": "Also install 'google-cloud-cli-tests'"
         }
     },
     "installsAfter": [


### PR DESCRIPTION
This PR expands the the optional installs with the full list of available optional packages, like `google-cloud-cli-app-engine-python`.