### PR TITLE
Fix: google-cloud CLI installation script to use gpg for key import

### DIFF
--- a/src/google-cloud-cli/install.sh
+++ b/src/google-cloud-cli/install.sh
@@ -69,7 +69,7 @@ install_using_apt() {
     # Install dependencies
     check_packages apt-transport-https curl ca-certificates gnupg python3
     # Import key
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
     apt_get_update
 


### PR DESCRIPTION
Fixes #35

## Description

This PR fixes the Google Cloud CLI installation script to work with modern Ubuntu/Debian systems by replacing the deprecated apt-key command with the recommended gpg approach.

## Problem

The current installation script fails on Ubuntu 22.04+ with the error:
```shell
apt-key: command not found
```

## Solution

Replaced apt-key usage with gpg --dearmor to properly handle GPG key import

ref. https://github.com/google-research/google-research/blob/46fe0fb7a0e36611b2ade273819ce35b0bd1ccc4/learning_to_clarify/Dockerfile#L20
